### PR TITLE
fix: navigate to dashboard instead of select-profile for logged-in users

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,25 +2,56 @@ import LinkButton from '@/components/LinkButton';
 import { createClient } from '@/utils/supabase/server';
 import { redirect } from 'next/navigation';
 
+const HERO_STATS = [
+  { value: '+500', label: 'fichas generadas' },
+  { value: '24/7', label: 'acceso inmediato' },
+  { value: '100%', label: 'personalizable' },
+];
+
+const FEATURES = [
+  {
+    icon: 'psychology',
+    title: 'Personalización inmediata',
+    description:
+      'Actividades adaptadas al curso y los gustos de cada hijo, listas para imprimir y usar sin complicaciones.',
+  },
+  {
+    icon: 'edit_square',
+    title: 'Confianza y motivación',
+    description:
+      'Celebramos cada acierto y fomentamos la autoestima con un sistema de refuerzo positivo tangible y divertido.',
+  },
+  {
+    icon: 'auto_stories',
+    title: 'Gamificación física',
+    description:
+      'Al completar actividades, tu hijo recibe recompensas tangibles que hacen visible su progreso y logros.',
+  },
+];
+
+const PRODUCT_BULLETS = [
+  'Fichas PDF listas para imprimir',
+  'Guía para padres incluida',
+  'Gamificación física y motivadora',
+];
+
 export default async function HomePage() {
-  // Verificar si el usuario está logueado
   const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();
 
-  // Si está logueado, redirigir al dashboard
   if (user) {
-    redirect('/dashboard/select-profile');
+    redirect('/dashboard');
   }
 
   return (
-    <>
-      {/* Hero Section */}
-      <section className="relative overflow-hidden pt-12 pb-20 lg:pt-20 lg:pb-32">
-        <div className="max-w-7xl mx-auto px-4 grid lg:grid-cols-2 gap-12 items-center">
+    <div className="space-y-24 pb-24">
+      <section className="relative overflow-hidden bg-gradient-to-br from-background-dark via-[#101a2b] to-background-dark text-white">
+        <div className="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-b from-transparent to-background-light dark:to-background-dark" />
+        <div className="relative max-w-7xl mx-auto px-4 py-16 lg:py-24 grid lg:grid-cols-2 gap-12 items-center">
           <div className="flex flex-col gap-8">
-            <div className="inline-flex items-center gap-2 bg-primary/10 dark:bg-orange-900/30 text-orange-300 px-3 py-1 rounded-full w-fit">
+            <div className="inline-flex items-center gap-2 bg-white/10 text-primary px-3 py-1 rounded-full w-fit">
               <span className="material-symbols-outlined text-sm">
                 auto_awesome
               </span>
@@ -29,20 +60,20 @@ export default async function HomePage() {
               </span>
             </div>
             <div className="space-y-4">
-              <h1 className="text-4xl lg:text-6xl font-black text-[#111813] dark:text-white leading-[1.1] tracking-tight">
-                <span className="text-primary dark:text-primary-100 underline decoration-primary/20 underline-offset-8">
+              <h1 className="text-4xl lg:text-6xl font-black leading-tight tracking-tight">
+                <span className="text-primary underline decoration-primary/20 underline-offset-8">
                   Acompaña
                 </span>{' '}
                 el aprendizaje de tus hijos, curso a curso
               </h1>
-              <p className="text-lg lg:text-xl text-slate-600 dark:text-slate-400 max-w-lg leading-relaxed">
+              <p className="text-lg lg:text-xl text-white/80 max-w-xl leading-relaxed">
                 Actividades personalizadas que conectan los intereses de tu hijo
                 con su curso. Estudio efectivo, motivador y sin estrés.
               </p>
             </div>
-            <div className="flex flex-col sm:flex-row gap-6 items-start">
+            <div className="flex flex-col sm:flex-row gap-4">
               <div className="flex flex-col gap-2">
-                <span className="text-xs font-bold text-orange-600 bg-orange-100 dark:bg-orange-900/30 dark:text-orange-300 px-3 py-1 rounded-full w-fit">
+                <span className="text-xs font-bold text-orange-300 bg-white/10 px-3 py-1 rounded-full w-fit">
                   🔥 Acceso Beta Gratuito (Plazas Limitadas)
                 </span>
                 <LinkButton href="/register" variant="big">
@@ -52,35 +83,47 @@ export default async function HomePage() {
                   </span>
                 </LinkButton>
               </div>
-
-              <div className="flex items-center gap-3 px-4 py-2 border border-slate-200 dark:border-slate-800 rounded-xl mt-2 sm:mt-8">
+              <div className="flex items-center gap-3 px-4 py-2 border border-white/20 rounded-xl">
                 <div className="flex -space-x-2">
-                  <div className="w-8 h-8 rounded-full border-2 border-white bg-slate-200"></div>
-                  <div className="w-8 h-8 rounded-full border-2 border-white bg-slate-300"></div>
-                  <div className="w-8 h-8 rounded-full border-2 border-white bg-slate-400"></div>
+                  <div className="w-8 h-8 rounded-full border-2 border-white bg-slate-200" />
+                  <div className="w-8 h-8 rounded-full border-2 border-white bg-slate-300" />
+                  <div className="w-8 h-8 rounded-full border-2 border-white bg-slate-400" />
                 </div>
-                <span className="text-xs font-medium text-slate-500">
+                <span className="text-xs font-medium text-white/80">
                   +500 fichas generadas
                 </span>
               </div>
             </div>
           </div>
-          <div className="relative">
-            <div className="absolute -inset-4 bg-primary/20 blur-3xl rounded-full opacity-30"></div>
-            <div
-              className="relative aspect-[4/3] rounded-2xl overflow-hidden shadow-2xl border-8 border-white dark:border-slate-800"
-              style={{
-                backgroundImage:
-                  'url("https://lh3.googleusercontent.com/aida-public/AB6AXuAEuNJ-VJNWX4ukpQHGhJKfmyH8-v-8cTcaweu1yclAbV17tCytS9KGamN91f1GuOQjCct0rG5id7Taohu-MEYCsIsFAI7kHfjqdOSilm9nPdKOSIXgCKWgntSvsWwjFK-D_xSyEKYe-qKltTDhv4le_1NYbqGqVUqCGRI8ctbvivfw_ljU1fQvZdGlc_pCWwx1Qp0HwIMhYTpVn-H_yPJeJkdCU_srAXdEpdDqzvG3XGOMR5sc9JG3-uQfI4V-Yi1OLmrVsf-YKPk")',
-                backgroundSize: 'cover',
-                backgroundPosition: 'center',
-              }}
-            ></div>
+          <div className="grid grid-cols-1 gap-6">
+            <div className="relative">
+              <div className="absolute -inset-4 bg-primary/20 blur-3xl rounded-full opacity-30" />
+              <div
+                className="relative aspect-[4/3] rounded-2xl overflow-hidden shadow-2xl border-8 border-white/70"
+                style={{
+                  backgroundImage:
+                    'url("https://lh3.googleusercontent.com/aida-public/AB6AXuAEuNJ-VJNWX4ukpQHGhJKfmyH8-v-8cTcaweu1yclAbV17tCytS9KGamN91f1GuOQjCct0rG5id7Taohu-MEYCsIsFAI7kHfjqdOSilm9nPdKOSIXgCKWgntSvsWwjFK-D_xSyEKYe-qKltTDhv4le_1NYbqGqVUqCGRI8ctbvivfw_ljU1fQvZdGlc_pCWwx1Qp0HwIMhYTpVn-H_yPJeJkdCU_srAXdEpdDqzvG3XGOMR5sc9JG3-uQfI4V-Yi1OLmrVsf-YKPk")',
+                  backgroundSize: 'cover',
+                  backgroundPosition: 'center',
+                }}
+              />
+            </div>
+            <div className="grid grid-cols-3 gap-4 bg-white/5 border border-white/10 rounded-2xl p-6">
+              {HERO_STATS.map((stat) => (
+                <div key={stat.label} className="text-center">
+                  <p className="text-3xl font-black text-primary">
+                    {stat.value}
+                  </p>
+                  <p className="text-xs uppercase tracking-widest text-white/70">
+                    {stat.label}
+                  </p>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
       </section>
 
-      {/* Features Grid */}
       <section className="py-24 bg-white dark:bg-slate-900/50">
         <div className="max-w-7xl mx-auto px-4">
           <div className="text-center max-w-3xl mx-auto mb-16 space-y-4">
@@ -93,61 +136,31 @@ export default async function HomePage() {
             </p>
           </div>
           <div className="grid md:grid-cols-3 gap-8">
-            {/* Feature 1 */}
-            <div className="bg-background-light dark:bg-background-dark p-8 rounded-2xl border border-primary/5 hover:border-primary/20 transition-all group">
-              <div className="w-14 h-14 bg-primary/10 rounded-xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform">
-                <span className="material-symbols-outlined text-primary text-3xl">
-                  psychology
-                </span>
-              </div>
-              <h3 className="text-xl font-bold mb-3 dark:text-white">
-                Personalización inmediata
-              </h3>
-              <p className="text-slate-600 dark:text-slate-400 leading-relaxed">
-                Actividades adaptadas al curso y los gustos de cada hijo, listas
-                para imprimir y usar sin complicaciones.
-              </p>
-            </div>
-
-            {/* Feature 2 */}
-            <div className="bg-background-light dark:bg-background-dark p-8 rounded-2xl border border-primary/5 hover:border-primary/20 transition-all group">
-              <div className="w-14 h-14 bg-primary/10 rounded-xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform">
-                <span className="material-symbols-outlined text-primary text-3xl">
-                  edit_square
-                </span>
-              </div>
-              <h3 className="text-xl font-bold mb-3 dark:text-white">
-                Confianza y motivación
-              </h3>
-              <p className="text-slate-600 dark:text-slate-400 leading-relaxed">
-                Celebramos cada acierto y fomentamos la autoestima con un
-                sistema de refuerzo positivo tangible y divertido.
-              </p>
-            </div>
-
-            {/* Feature 3 */}
-            <div className="bg-background-light dark:bg-background-dark p-8 rounded-2xl border border-primary/5 hover:border-primary/20 transition-all group">
-              <div className="w-14 h-14 bg-primary/10 rounded-xl flex items-center justify-center mb-6 group-hover:scale-110 transition-transform">
-                <span className="material-symbols-outlined text-primary text-3xl">
-                  auto_stories
-                </span>
-              </div>
-              <h3 className="text-xl font-bold mb-3 dark:text-white">
-                Gamificación física
-              </h3>
-              <p className="text-slate-600 dark:text-slate-400 leading-relaxed">
-                Al completar actividades, tu hijo recibe recompensas tangibles
-                que hacen visible su progreso y logros.
-              </p>
-            </div>
+            {FEATURES.map((feature) => (
+              <article
+                key={feature.title}
+                className="bg-background-light dark:bg-[#111b2a] p-8 rounded-2xl border border-primary/5 hover:border-primary/20 transition-all"
+              >
+                <div className="w-14 h-14 bg-primary/10 rounded-xl flex items-center justify-center mb-6">
+                  <span className="material-symbols-outlined text-primary text-3xl">
+                    {feature.icon}
+                  </span>
+                </div>
+                <h3 className="text-xl font-bold mb-3 dark:text-white">
+                  {feature.title}
+                </h3>
+                <p className="text-slate-600 dark:text-slate-400 leading-relaxed">
+                  {feature.description}
+                </p>
+              </article>
+            ))}
           </div>
         </div>
       </section>
 
-      {/* Product Showcase */}
       <section className="py-24">
         <div className="max-w-7xl mx-auto px-4">
-          <div className="bg-primary/5 rounded-[2rem] p-8 lg:p-16 overflow-hidden relative">
+          <div className="bg-primary/5 rounded-[2rem] p-8 lg:p-16 overflow-hidden relativo">
             <div className="grid lg:grid-cols-2 gap-12 items-center relative z-10">
               <div className="space-y-6">
                 <h2 className="text-3xl lg:text-5xl font-black text-[#111813] dark:text-white leading-tight">
@@ -159,107 +172,70 @@ export default async function HomePage() {
                   física con el estudio.
                 </p>
                 <ul className="space-y-4">
-                  <li className="flex items-center gap-3">
-                    <div className="bg-primary text-white p-1 rounded-full">
-                      <span className="material-symbols-outlined text-xs font-bold">
-                        check
+                  {PRODUCT_BULLETS.map((item) => (
+                    <li key={item} className="flex items-center gap-3">
+                      <div className="bg-primary text-white p-1 rounded-full">
+                        <span className="material-symbols-outlined text-xs font-bold">
+                          check
+                        </span>
+                      </div>
+                      <span className="font-medium dark:text-slate-200">
+                        {item}
                       </span>
-                    </div>
-                    <span className="font-medium dark:text-slate-200">
-                      Fichas PDF listas para imprimir
-                    </span>
-                  </li>
-                  <li className="flex items-center gap-3">
-                    <div className="bg-primary text-white p-1 rounded-full">
-                      <span className="material-symbols-outlined text-xs font-bold">
-                        check
-                      </span>
-                    </div>
-                    <span className="font-medium dark:text-slate-200">
-                      Guía para padres incluida
-                    </span>
-                  </li>
-                  <li className="flex items-center gap-3">
-                    <div className="bg-primary text-white p-1 rounded-full">
-                      <span className="material-symbols-outlined text-xs font-bold">
-                        check
-                      </span>
-                    </div>
-                    <span className="font-medium dark:text-slate-200">
-                      Gamificación física y motivadora
-                    </span>
-                  </li>
+                    </li>
+                  ))}
                 </ul>
               </div>
               <div className="grid grid-cols-2 gap-4">
-                <div
-                  className="aspect-square bg-white dark:bg-slate-800 rounded-2xl shadow-xl p-4 rotate-3 border-4 border-white dark:border-slate-700"
-                  style={{
-                    backgroundImage:
-                      'url("https://lh3.googleusercontent.com/aida-public/AB6AXuBd7OsKkM0BQ6n24HOkz7p0guJ6bfusvkPfEIRe_lxcsxs_l6atjpHc39yawDuTt7YygOnqv9GYd4G9sAMv5chX1eH3Ahe0jY46JHfJohgsbFGU6IB8pBiGpviEil--RMJGT8PODmlM9lMkF9UCDE7aK_XFl6hXP2EuOBO7gpGLN-1U6hCwnO0Dvv4Ikx1l1I0q0ktQDBhEcpmWsBUhyKGPAcVYIEmdCB7XfHisQSjt7B8sdJN1-9nbpY8KL9tu4D-oHCcpt5qwdH4")',
-                    backgroundSize: 'cover',
-                  }}
-                ></div>
-                <div
-                  className="aspect-square bg-white dark:bg-slate-800 rounded-2xl shadow-xl p-4 -rotate-3 border-4 border-white dark:border-slate-700 mt-12"
-                  style={{
-                    backgroundImage:
-                      'url("https://lh3.googleusercontent.com/aida-public/AB6AXuBwtUJsfiQ72wkoexFfB5ogofk_5h2Bs32sDKmXbndpplK93eySIBoEol3FDj7Ojq5iF34qwWhugMwRrF_gD5NUcy7Z-oaXEs4pcEDN1g4M__cAfLEXKWpOk7Q7gLCubUxV1QGIVYedPuzZCDdecSEwTWNRnP3QTYRR4d5_VbuyXFZsqlol8dCJkSKiCpyusKKpKR9RU9CR2cB9tu2cBfLHSQjAtQReTlzeyHP8v9pyxDFhhcp7G1_LzmLZamS_pfENUJyZJKUU_JU")',
-                    backgroundSize: 'cover',
-                  }}
-                ></div>
+                {[
+                  'https://lh3.googleusercontent.com/aida-public/AB6AXuBd7OsKkM0BQ6n24HOkz7p0guJ6bfusvkPfEIRe_lxcsxs_l6atjpHc39yawDuTt7YygOnqv9GYd4G9sAMv5chX1eH3Ahe0jY46JHfJohgsbFGU6IB8pBiGpviEil--RMJGT8PODmlM9lMkF9UCDE7aK_XFl6hXP2EuOBO7gpGLN-1U6hCwnO0Dvv4Ikx1l1I0q0ktQDBhEcpmWsBUhyKGPAcVYIEmdCB7XfHisQSjt7B8sdJN1-9nbpY8KL9tu4D-oHCcpt5qwdH4',
+                  'https://lh3.googleusercontent.com/aida-public/AB6AXuBwtUJsfiQ72wkoexFfB5ogofk_5h2Bs32sDKmXbndpplK93eySIBoEol3FDj7Ojq5iF34qwWhugMwRrF_gD5NUcy7Z-oaXEs4pcEDN1g4M__cAfLEXKWpOk7Q7gLCubUxV1QGIVYedPuzZCDdecSEwTWNRnP3QTYRR4d5_VbuyXFZsqlol8dCJkSKiCpyusKKpKR9RU9CR2cB9tu2cBfLHSQjAtQReTlzeyHP8v9pyxDFhhcp7G1_LzmLZamS_pfENUJyZJKUU_JU',
+                ].map((url, idx) => (
+                  <div
+                    key={url}
+                    className={`aspect-square bg-white dark:bg-slate-800 rounded-2xl shadow-xl border-4 border-white dark:border-slate-700 ${idx === 0 ? 'rotate-3' : '-rotate-3 mt-12'}`}
+                    style={{
+                      backgroundImage: `url("${url}")`,
+                      backgroundSize: 'cover',
+                    }}
+                  />
+                ))}
               </div>
             </div>
           </div>
         </div>
       </section>
 
-      {/* Stats Section */}
       <section className="py-16 bg-background-light dark:bg-background-dark/50">
         <div className="max-w-7xl mx-auto px-4">
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-8">
-            <div className="dark:bg-orange-900/60 rounded-2xl flex flex-col items-center text-center gap-2">
-              <p className="text-orange-400 text-4xl lg:text-5xl font-black">
-                100%
-              </p>
-              <p className="text-sm font-bold text-orange-400 uppercase tracking-widest">
-                Personalizable
-              </p>
-            </div>
-            <div className="dark:bg-orange-900/60 rounded-2xl flex flex-col items-center text-center gap-2">
-              <p className="text-orange-400 text-4xl lg:text-5xl font-black">
-                500+
-              </p>
-              <p className="text-sm font-bold text-orange-400 uppercase tracking-widest">
-                Fichas Generadas
-              </p>
-            </div>
-            <div className="dark:bg-orange-900/60 rounded-2xl flex flex-col items-center text-center gap-2">
-              <p className="text-orange-400 text-4xl lg:text-5xl font-black">
-                24/7
-              </p>
-              <p className="text-sm font-bold text-orange-400 uppercase tracking-widest">
-                Acceso Inmediato
-              </p>
-            </div>
-            <div className="dark:bg-orange-900/60 rounded-2xl flex flex-col items-center text-center gap-2">
-              <p className="text-orange-400 text-4xl lg:text-5xl font-black">
-                0
-              </p>
-              <p className="text-sm font-bold text-orange-400 uppercase tracking-widest">
-                Estrés en Casa
-              </p>
-            </div>
+            {[
+              { value: '100%', label: 'Personalizable' },
+              { value: '500+', label: 'Fichas Generadas' },
+              { value: '24/7', label: 'Acceso Inmediato' },
+              { value: '0', label: 'Estrés en Casa' },
+            ].map((stat) => (
+              <div
+                key={stat.label}
+                className="rounded-2xl flex flex-col items-center text-center gap-2 bg-white dark:bg-orange-900/40 p-6"
+              >
+                <p className="text-orange-500 text-4xl lg:text-5xl font-black">
+                  {stat.value}
+                </p>
+                <p className="text-sm font-bold text-orange-500 uppercase tracking-widest">
+                  {stat.label}
+                </p>
+              </div>
+            ))}
           </div>
         </div>
       </section>
 
-      {/* CTA Section */}
       <section className="py-24">
         <div className="max-w-4xl mx-auto px-4 text-center">
           <div className="bg-slate-900 dark:bg-slate-800 p-12 lg:p-20 rounded-[3rem] shadow-2xl relative overflow-hidden">
-            <div className="absolute top-0 right-0 w-64 h-64 bg-primary/20 blur-[100px] rounded-full -mr-32 -mt-32"></div>
-            <div className="relative z-10 space-y-8">
+            <div className="absolute top-0 right-0 w-64 h-64 bg-primary/20 blur-[100px] rounded-full -mr-32 -mt-32" />
+            <div className="relative space-y-8">
               <h2 className="text-4xl lg:text-5xl font-black text-white leading-tight">
                 Transforma la hora de estudio
               </h2>
@@ -278,6 +254,6 @@ export default async function HomePage() {
           </div>
         </div>
       </section>
-    </>
+    </div>
   );
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,24 +1,43 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import { createClient } from '@/utils/supabase/server';
 import HeaderAuth from './HeaderAuth';
+import ThemeToggle from './ui/theme-toggle';
+import MobileMenu from './ui/mobile-menu';
 
-export default function Header() {
+export default async function Header() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const logoHref = user ? '/dashboard' : '/';
+
   return (
     <header className="sticky top-0 z-50 bg-white/80 dark:bg-background-dark/80 backdrop-blur-md border-b border-primary/10">
       <div className="max-w-7xl mx-auto px-4 h-16 flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <Link href="/dashboard" className="flex items-center gap-2">
-            <Image
-              src="/logo_tutorai.png"
-              alt="TUTOR_AI Logo"
-              width={32}
-              height={32}
-              className="object-contain mr-2"
-            />
-            <span className="text-xl font-bold tracking-tight">TUTOR_AI</span>
-          </Link>
+        {/* Logo */}
+        <Link href={logoHref} className="flex items-center gap-2">
+          <Image
+            src="/logo_tutorai.png"
+            alt="TUTOR_AI Logo"
+            width={40}
+            height={40}
+            className="object-contain"
+          />
+          <span className="text-[#111813] dark:text-white text-lg font-bold leading-tight tracking-tight">
+            TUTOR_AI
+          </span>
+        </Link>
+
+        {/* Desktop: Theme Toggle + HeaderAuth */}
+        <div className="hidden md:flex items-center gap-4">
+          <ThemeToggle />
+          <HeaderAuth />
         </div>
-        <HeaderAuth />
+
+        {/* Mobile: Solo menú hamburguesa */}
+        <MobileMenu />
       </div>
     </header>
   );

--- a/components/ui/mobile-menu.tsx
+++ b/components/ui/mobile-menu.tsx
@@ -1,0 +1,229 @@
+/* eslint-disable react-hooks/set-state-in-effect */
+'use client';
+
+import { Menu, X } from 'lucide-react';
+import { createPortal } from 'react-dom';
+import { useState, useEffect } from 'react';
+import { useAuth } from '@/context/auth-context';
+import CreditosBadge from '../CreditosBadge';
+import Button from '../Button';
+import LinkButton from '../LinkButton';
+import ThemeToggle from './theme-toggle';
+
+interface MobileMenuProps {
+  navigationLinks?: Array<{
+    label: string;
+    href: string;
+  }>;
+}
+
+export default function MobileMenu({ navigationLinks = [] }: MobileMenuProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [portalReady, setPortalReady] = useState(false);
+  const { user, signOut } = useAuth();
+
+  useEffect(() => {
+    setPortalReady(true);
+  }, []);
+
+  // Prevenir scroll cuando el menú está abierto
+  useEffect(() => {
+    if (!portalReady) {
+      return;
+    }
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+
+    // Cleanup al desmontar
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [isOpen, portalReady]);
+
+  const closeMenu = () => setIsOpen(false);
+
+  return (
+    <>
+      {/* Botón hamburguesa */}
+      <button
+        onClick={() => setIsOpen(true)}
+        className="
+          md:hidden w-10 h-10 rounded-lg 
+          bg-white dark:bg-dark-surface 
+          border border-slate-300 dark:border-dark-border
+          flex items-center justify-center
+          shadow-sm hover:shadow-md
+          transition-shadow duration-200
+          focus:outline-none focus:ring-2 focus:ring-primary/20
+        "
+        aria-label="Abrir menú"
+      >
+        <Menu
+          className="w-5 h-5 text-slate-600 dark:text-slate-300"
+          strokeWidth={2}
+        />
+      </button>
+
+      {portalReady &&
+        createPortal(
+          <>
+            {/* Overlay */}
+            {isOpen && (
+              <div
+                className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[120] md:hidden"
+                onClick={closeMenu}
+                aria-hidden="true"
+              />
+            )}
+
+            {/* Menú deslizable */}
+            <div
+              className={`
+                fixed top-0 right-0 h-full w-full max-w-[380px]
+                bg-white dark:bg-[#121a2d]
+                border-l border-slate-200 dark:border-white/10
+                shadow-2xl z-[130] md:hidden
+                transform transition-transform duration-300 ease-out
+                ${isOpen ? 'translate-x-0 pointer-events-auto' : 'translate-x-full pointer-events-none'}
+                overflow-y-auto
+              `}
+            >
+              {/* Header del menú */}
+              <div className="flex items-center justify-between p-6 border-b border-slate-200 dark:border-dark-border">
+                <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+                  Menú
+                </h3>
+                <button
+                  onClick={closeMenu}
+                  className="
+                    w-8 h-8 rounded-lg 
+                    bg-slate-100 dark:bg-dark-highlight
+                    flex items-center justify-center
+                    hover:bg-slate-200 dark:hover:bg-slate-600
+                    transition-colors duration-200
+                  "
+                  aria-label="Cerrar menú"
+                >
+                  <X
+                    className="w-4 h-4 text-slate-600 dark:text-slate-300"
+                    strokeWidth={2}
+                  />
+                </button>
+              </div>
+
+              {/* Contenido del menú */}
+              <div className="flex flex-col min-h-[100dvh] text-slate-900 dark:text-slate-100">
+                {/* Sección de navegación futura */}
+                {navigationLinks.length > 0 && (
+                  <nav className="px-6 py-4 border-b border-slate-200 dark:border-white/10">
+                    <h4 className="text-sm font-medium text-slate-700 dark:text-white mb-3">
+                      Navegación
+                    </h4>
+                    <ul className="space-y-2">
+                      {navigationLinks.map((link, index) => (
+                        <li key={index}>
+                          <a
+                            href={link.href}
+                            onClick={closeMenu}
+                            className="
+                        block px-3 py-2 rounded-lg
+                        text-slate-600 dark:text-slate-200
+                        hover:bg-slate-100 dark:hover:bg-white/10
+                        transition-colors duration-200
+                      "
+                          >
+                            {link.label}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </nav>
+                )}
+
+                {/* Sección de tema */}
+                <div className="px-6 py-4 border-b border-slate-200 dark:border-white/10 bg-white/80 dark:bg-white/5">
+                  <h4 className="text-sm font-medium text-slate-700 dark:text-white mb-3">
+                    Apariencia
+                  </h4>
+                  <div className="flex items-center justify-between gap-4">
+                    <div className="text-left">
+                      <p className="text-sm font-medium text-slate-700 dark:text-white">
+                        Tema
+                      </p>
+                      <p className="text-xs text-slate-500 dark:text-slate-300">
+                        Claro / Oscuro
+                      </p>
+                    </div>
+                    <ThemeToggle className="flex-shrink-0" />
+                  </div>
+                </div>
+
+                {/* Sección de usuario/auth */}
+                <div className="px-6 py-4 flex-1 bg-white/90 dark:bg-white/5">
+                  <h4 className="text-sm font-medium text-slate-700 dark:text-white mb-3">
+                    Cuenta
+                  </h4>
+
+                  {user ? (
+                    <div className="space-y-4">
+                      <div className="p-3 bg-slate-50 dark:bg-white/10 rounded-lg">
+                        <p className="text-sm font-medium text-slate-700 dark:text-white mb-1">
+                          Hola,
+                        </p>
+                        <p className="text-sm text-slate-600 dark:text-slate-200">
+                          {user.user_metadata?.name ||
+                            user.identities?.[0]?.identity_data?.name ||
+                            'Usuario'}
+                        </p>
+                      </div>
+
+                      <div className="flex justify-center">
+                        <CreditosBadge />
+                      </div>
+
+                      <div className="space-y-3">
+                        <div onClick={closeMenu}>
+                          <LinkButton href="/select-profile">
+                            Abrir app
+                          </LinkButton>
+                        </div>
+
+                        <Button
+                          onClick={() => {
+                            signOut();
+                            closeMenu();
+                          }}
+                        >
+                          Salir
+                        </Button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="space-y-3">
+                      <div className="w-full" onClick={closeMenu}>
+                        <LinkButton href="/login">Login</LinkButton>
+                      </div>
+                      <div className="w-full" onClick={closeMenu}>
+                        <LinkButton href="/register">Probar gratis</LinkButton>
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                {/* Footer opcional */}
+                <div className="px-6 py-4 border-t border-slate-200 dark:border-dark-border">
+                  <p className="text-xs text-slate-500 dark:text-slate-400 text-center">
+                    TUTOR_AI © {new Date().getFullYear()}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </>,
+          document.body
+        )}
+    </>
+  );
+}

--- a/components/ui/theme-toggle.tsx
+++ b/components/ui/theme-toggle.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
+
+interface ThemeToggleProps {
+  className?: string;
+}
+
+export default function ThemeToggle({ className = '' }: ThemeToggleProps) {
+  const { resolvedTheme, setTheme } = useTheme();
+
+  const handleToggle = () => {
+    setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
+  };
+
+  return (
+    <button
+      onClick={handleToggle}
+      className={`
+        relative w-10 h-10 rounded-full 
+        bg-slate-100 dark:bg-dark-highlight 
+        border border-slate-200 dark:border-dark-border
+        shadow-sm
+        flex items-center justify-center
+        focus:outline-none focus:ring-2 focus:ring-primary/20
+        ${className}
+      `}
+      aria-label="Cambiar tema"
+    >
+      <Sun className="w-5 h-5 text-amber-400 dark:hidden" strokeWidth={2} />
+      <Moon
+        className="w-5 h-5 text-slate-500 hidden dark:block"
+        strokeWidth={2}
+      />
+    </button>
+  );
+}


### PR DESCRIPTION
- Header.tsx now redirects logo to /dashboard when authenticated, / when not
- page.tsx redirects authenticated users directly to /dashboard
- Makes /dashboard the true 'home' for authenticated users
- Logo click always goes to the correct destination based on auth state
- Add ThemeToggle and MobileMenu UI components