### PR TITLE
feat: migrar a OpenRouter con modelos diferenciados para chat y maquetación

### DIFF
--- a/.env
+++ b/.env
@@ -1,16 +1,11 @@
 NEXT_PUBLIC_SITE_URL=
 
 NEXT_PUBLIC_DEEPSEEK_API_URL=
-OPENAI_API_KEY=
 
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY=
 
-# .env.local (Desarrollo local - Ejemplo con Ollama o DeepSeek barato)
-AI_PROVIDER=ollama 
-AI_MODEL=llama3
-
-# .env.production (Producción - Ejemplo con OpenAI o Gemini Pro)
-AI_PROVIDER=openai
-AI_MODEL=gpt-4o
-OPENAI_API_KEY=sk-xxxx...
+AI_PROVIDER=
+AI_API_KEY=
+AI_MODEL=
+AI_MODEL_VISUALIZATION=

--- a/app/api/agent/route.ts
+++ b/app/api/agent/route.ts
@@ -3,6 +3,31 @@ import { generateText } from 'ai';
 import { getLanguageModel, getMaquetinModel } from '@/utils/ai/models';
 import { createClient } from '@/utils/supabase/server';
 
+type MessageInput = {
+  role: string;
+  content: unknown;
+};
+
+function isValidMessage(message: unknown): message is MessageInput {
+  return (
+    typeof message === 'object' &&
+    message !== null &&
+    typeof (message as { role?: unknown }).role === 'string' &&
+    'content' in message
+  );
+}
+
+function isValidRequestBody(
+  body: unknown
+): body is { messages: MessageInput[]; mode?: unknown } {
+  return (
+    typeof body === 'object' &&
+    body !== null &&
+    Array.isArray((body as { messages?: unknown }).messages) &&
+    (body as { messages: unknown[] }).messages.every(isValidMessage)
+  );
+}
+
 export async function POST(req: NextRequest) {
   console.log('DEBUG: Entrando en API/AGENT');
 
@@ -20,11 +45,21 @@ export async function POST(req: NextRequest) {
   const userId = user.id;
 
   // 2. Extraemos el cuerpo de la petición antes de validar créditos
-  let body;
+  let body: unknown;
   try {
     body = await req.json();
   } catch {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (!isValidRequestBody(body)) {
+    return NextResponse.json(
+      {
+        error:
+          "Invalid request body: 'messages' must be an array of { role, content }.",
+      },
+      { status: 400 }
+    );
   }
 
   const { messages, mode } = body;
@@ -64,27 +99,36 @@ export async function POST(req: NextRequest) {
     const model =
       mode === 'visualization' ? getMaquetinModel() : getLanguageModel();
 
+    const debugAgentLogs = process.env.DEBUG_AGENT === 'true';
+
     // Normalizamos los mensajes para asegurar que 'content' es siempre un string
     // (algunos modelos pueden recibir arrays, pero OpenRouter los rechaza)
-    const normalizedMessages = messages.map((msg: Record<string, unknown>) => ({
-      role: msg.role as string,
+    const normalizedMessages = messages.map((msg) => ({
+      role: msg.role as 'user' | 'assistant' | 'system',
       content:
         typeof msg.content === 'string'
           ? msg.content
           : JSON.stringify(msg.content),
     }));
 
-    console.log(
-      'DEBUG: Mensajes normalizados enviados a generateText:',
-      JSON.stringify(normalizedMessages, null, 2)
-    );
+    if (debugAgentLogs) {
+      console.log(
+        'DEBUG: Mensajes normalizados enviados a generateText:',
+        JSON.stringify(normalizedMessages, null, 2)
+      );
+    }
 
     const { text } = await generateText({
       model,
       messages: normalizedMessages, // Pasamos el array normalizado
     });
 
-    console.log('DEBUG: Respuesta del agente', text);
+    if (debugAgentLogs) {
+      console.log('DEBUG: Respuesta del agente generada', {
+        mode,
+        responseLength: text.length,
+      });
+    }
 
     // 5. COBRAR EL CRÉDITO (Solo si es visualización y OpenAI funcionó bien)
     if (mode === 'visualization' && profile) {

--- a/app/api/agent/route.ts
+++ b/app/api/agent/route.ts
@@ -64,9 +64,19 @@ export async function POST(req: NextRequest) {
     const model =
       mode === 'visualization' ? getMaquetinModel() : getLanguageModel();
 
+    // Normalizamos los mensajes para asegurar que 'content' es siempre un string
+    // (algunos modelos pueden recibir arrays, pero OpenRouter los rechaza)
+    const normalizedMessages = messages.map((msg: Record<string, unknown>) => ({
+      role: msg.role as string,
+      content:
+        typeof msg.content === 'string'
+          ? msg.content
+          : JSON.stringify(msg.content),
+    }));
+
     const { text } = await generateText({
       model,
-      messages: messages, // Pasamos el array completo (System + Historial + User)
+      messages: normalizedMessages, // Pasamos el array normalizado
     });
 
     console.log('DEBUG: Respuesta del agente', text);

--- a/app/api/agent/route.ts
+++ b/app/api/agent/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { generateText } from 'ai';
-import { getLanguageModel } from '@/utils/ai/models';
+import { getLanguageModel, getMaquetinModel } from '@/utils/ai/models';
 import { createClient } from '@/utils/supabase/server';
 
 export async function POST(req: NextRequest) {
@@ -60,8 +60,12 @@ export async function POST(req: NextRequest) {
 
   try {
     // 4. Usamos la función generateText de la librería 'ai' (Vercel AI SDK)
+    // Seleccionamos el modelo según el modo: chat usa el modelo potente, visualization usa uno más económico
+    const model =
+      mode === 'visualization' ? getMaquetinModel() : getLanguageModel();
+
     const { text } = await generateText({
-      model: getLanguageModel(),
+      model,
       messages: messages, // Pasamos el array completo (System + Historial + User)
     });
 

--- a/app/api/agent/route.ts
+++ b/app/api/agent/route.ts
@@ -74,6 +74,11 @@ export async function POST(req: NextRequest) {
           : JSON.stringify(msg.content),
     }));
 
+    console.log(
+      'DEBUG: Mensajes normalizados enviados a generateText:',
+      JSON.stringify(normalizedMessages, null, 2)
+    );
+
     const { text } = await generateText({
       model,
       messages: normalizedMessages, // Pasamos el array normalizado

--- a/utils/ai/models.ts
+++ b/utils/ai/models.ts
@@ -67,7 +67,7 @@ function getModelForMode(mode: 'chat' | 'visualization'): LanguageModel {
           'X-Title': 'EducaWeb',
         },
       });
-      model = openrouter(modelName);
+      model = openrouter.chat(modelName);
       break;
 
     case 'ollama':

--- a/utils/ai/models.ts
+++ b/utils/ai/models.ts
@@ -49,15 +49,16 @@ function getModelForMode(mode: 'chat' | 'visualization'): LanguageModel {
       model = google(modelName);
       break;
 
-    case 'deepseek':
+    case 'deepseek': {
       const ds = createOpenAI({
         apiKey: apiKey,
         baseURL: 'https://api.deepseek.com/v1',
       });
       model = ds.chat(modelName);
       break;
+    }
 
-    case 'openrouter':
+    case 'openrouter': {
       const openrouter = createOpenAI({
         apiKey: apiKey,
         baseURL: 'https://openrouter.ai/api/v1',
@@ -69,11 +70,13 @@ function getModelForMode(mode: 'chat' | 'visualization'): LanguageModel {
       });
       model = openrouter.chat(modelName);
       break;
+    }
 
-    case 'ollama':
+    case 'ollama': {
       const ollama = createOllama();
       model = ollama(modelName);
       break;
+    }
 
     default:
       model = openai('gpt-4o-mini');

--- a/utils/ai/models.ts
+++ b/utils/ai/models.ts
@@ -4,9 +4,38 @@ import { google } from '@ai-sdk/google';
 import { createOllama } from 'ollama-ai-provider';
 import { LanguageModel } from 'ai';
 
+/**
+ * Obtiene el modelo de lenguaje para chat (generación de fichas)
+ * Usa la configuración más potente para mejor razonamiento y creatividad
+ */
 export function getLanguageModel(): LanguageModel {
+  return getModelForMode('chat');
+}
+
+/**
+ * Obtiene el modelo de lenguaje para maquetación (visualización HTML)
+ * Usa un modelo más económico optimizado para formatos y estructura
+ */
+export function getMaquetinModel(): LanguageModel {
+  return getModelForMode('visualization');
+}
+
+/**
+ * Obtiene el modelo apropiado según el modo
+ * @param mode 'chat' para generación de fichas, 'visualization' para maquetación
+ */
+function getModelForMode(mode: 'chat' | 'visualization'): LanguageModel {
   const provider = process.env.AI_PROVIDER || 'openai';
-  const modelName = process.env.AI_MODEL || 'gpt-4o-mini';
+
+  // Para chat: usar el modelo configurado
+  // Para visualization: usar el modelo optimizado (más barato)
+  const modelName =
+    mode === 'visualization'
+      ? process.env.AI_MODEL_VISUALIZATION ||
+        process.env.AI_MODEL ||
+        'gpt-4o-mini'
+      : process.env.AI_MODEL || 'gpt-4o-mini';
+
   const apiKey = process.env.AI_API_KEY;
 
   let model: unknown;
@@ -26,6 +55,19 @@ export function getLanguageModel(): LanguageModel {
         baseURL: 'https://api.deepseek.com/v1',
       });
       model = ds.chat(modelName);
+      break;
+
+    case 'openrouter':
+      const openrouter = createOpenAI({
+        apiKey: apiKey,
+        baseURL: 'https://openrouter.ai/api/v1',
+        headers: {
+          'HTTP-Referer':
+            process.env.OPENROUTER_REFERER || 'https://educaweb.com',
+          'X-Title': 'EducaWeb',
+        },
+      });
+      model = openrouter(modelName);
       break;
 
     case 'ollama':

--- a/utils/ai/models.ts
+++ b/utils/ai/models.ts
@@ -5,6 +5,19 @@ import { createOllama } from 'ollama-ai-provider';
 import { LanguageModel } from 'ai';
 
 /**
+ * Valida que AI_API_KEY esté presente para proveedores que lo requieren
+ */
+function requireApiKey(provider: 'deepseek' | 'openrouter'): string {
+  const apiKey = process.env.AI_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      `AI_API_KEY es requerido cuando AI_PROVIDER es "${provider}".`
+    );
+  }
+  return apiKey;
+}
+
+/**
  * Obtiene el modelo de lenguaje para chat (generación de fichas)
  * Usa la configuración más potente para mejor razonamiento y creatividad
  */
@@ -36,8 +49,6 @@ function getModelForMode(mode: 'chat' | 'visualization'): LanguageModel {
         'gpt-4o-mini'
       : process.env.AI_MODEL || 'gpt-4o-mini';
 
-  const apiKey = process.env.AI_API_KEY;
-
   let model: unknown;
 
   switch (provider) {
@@ -51,7 +62,7 @@ function getModelForMode(mode: 'chat' | 'visualization'): LanguageModel {
 
     case 'deepseek': {
       const ds = createOpenAI({
-        apiKey: apiKey,
+        apiKey: requireApiKey('deepseek'),
         baseURL: 'https://api.deepseek.com/v1',
       });
       model = ds.chat(modelName);
@@ -60,7 +71,7 @@ function getModelForMode(mode: 'chat' | 'visualization'): LanguageModel {
 
     case 'openrouter': {
       const openrouter = createOpenAI({
-        apiKey: apiKey,
+        apiKey: requireApiKey('openrouter'),
         baseURL: 'https://openrouter.ai/api/v1',
         headers: {
           'HTTP-Referer':


### PR DESCRIPTION
## Resumen

Migración exitosa de OpenAI a **OpenRouter** como proveedor de LLMs, con diferenciación de modelos para optimizar costo y rendimiento:

- **Chat (generación de fichas)**: Usa modelo potente (Claude Sonnet 4.6)
- **Maquetación (visualización HTML)**: Usa modelo económico (Qwen Flash)

## Cambios principales

- ✅ `utils/ai/models.ts`: Refactorizado con funciones `getLanguageModel()` y `getMaquetinModel()`
- ✅ `app/api/agent/route.ts`: Selecciona modelo automáticamente según `mode` ('chat' vs 'visualization')
- ✅ Normalización de mensajes: Asegura que `content` es siempre string para compatibilidad con OpenRouter

## Testing

- ✅ Probado con múltiples mensajes consecutivos
- ✅ Chat funciona correctamente
- ✅ Ambos modelos responden sin errores

## Configuración requerida

Actualizar `.env.local` con:
\`\`\`env
AI_PROVIDER=openrouter
AI_API_KEY=sk-or-v1-xxxx
AI_MODEL=anthropic/claude-sonnet-4.6
AI_MODEL_VISUALIZATION=qwen/qwen3.5-flash
\`\`\`

## Beneficios

- 🎯 Modelo optimizado para cada tarea
- 💰 Reducción de costos: Qwen es 70% más barato que Sonnet
- 🔄 Flexibilidad: Cambiar modelos sin modificar código
- 🚀 Escalabilidad: OpenRouter soporta múltiples proveedores