### PR TITLE
fix(dashboard): quitar header del chat, optimizar layout y agregar error handling

### DIFF
--- a/app/dashboard/chat/ChatInterface.tsx
+++ b/app/dashboard/chat/ChatInterface.tsx
@@ -40,59 +40,9 @@ export default function ChatInterface({
   onBackToSelector,
 }: ChatInterfaceProps) {
   return (
-    <>
-      <div className="h-16 shrink-0 border-b border-[#f0f2f4] dark:border-dark-border flex items-center justify-between px-4 lg:px-6">
-        <div className="flex items-center gap-2">
-          <span className="material-symbols-outlined text-primary">
-            edit_note
-          </span>
-          <div className="flex flex-col">
-            <h2 className="font-bold text-sm text-[#111318] dark:text-gray-100">
-              Creador de fichas {childInfo ? `para ${childInfo.name}` : ''}
-            </h2>
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="md:hidden">
-            <button
-              onClick={onVisualize}
-              disabled={htmlLoading || messages.length === 0}
-              className={`p-2 rounded-full transition-colors ${
-                htmlLoading || messages.length === 0
-                  ? 'text-gray-300 cursor-not-allowed'
-                  : 'text-primary hover:bg-indigo-50 dark:hover:bg-indigo-900/20'
-              }`}
-              title="Visualize"
-            >
-              <span
-                className={`material-symbols-outlined ${
-                  htmlLoading ? 'animate-spin' : ''
-                }`}
-              >
-                {htmlLoading ? 'sync' : 'preview'}
-              </span>
-            </button>
-          </div>
-          <div className="md:hidden" onClick={toggleSidebar}>
-            <span className="material-symbols-outlined text-gray-400">
-              menu_open
-            </span>
-          </div>
-          <button
-            onClick={onBackToSelector}
-            className="flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-gray-100 dark:hover:bg-dark-highlight transition-colors text-sm"
-            title="Cambiar estudiante"
-          >
-            <span className="material-symbols-outlined text-sm">
-              arrow_back
-            </span>
-            <span className="hidden sm:inline">Cambiar est.</span>
-          </button>
-        </div>
-      </div>
-
+    <div className="flex flex-col h-full overflow-hidden">
       {/* Topic Selector */}
-      <div className="px-4 lg:px-6 py-3 border-b border-[#f0f2f4] dark:border-dark-border bg-gray-50 dark:bg-dark-highlight">
+      <div className="shrink-0 px-4 lg:px-6 py-3 border-b border-[#f0f2f4] dark:border-dark-border bg-gray-50 dark:bg-dark-highlight">
         <label className="block text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">
           Tema de hoy
         </label>
@@ -132,7 +82,7 @@ export default function ChatInterface({
         )}
       </div>
 
-      <div className="flex-1 overflow-y-auto p-4 space-y-6 bg-background-light dark:bg-background-dark">
+      <div className="flex-1 overflow-auto p-4 space-y-6 bg-background-light dark:bg-background-dark">
         {messages.length === 0 && (
           <div className="text-center text-gray-600  dark:text-gray-300 mt-10">
             <p>Inicia una conversación con el agente.</p>
@@ -212,7 +162,7 @@ export default function ChatInterface({
         <div ref={messagesEndRef} />
       </div>
 
-      <div className="p-4 border-t border-[#f0f2f4] dark:border-dark-border bg-white dark:bg-dark-surface">
+      <div className="shrink-0 p-4 border-t border-[#f0f2f4] dark:border-dark-border bg-white dark:bg-dark-surface">
         <div className="relative group">
           <textarea
             value={input}
@@ -237,6 +187,6 @@ export default function ChatInterface({
           </button>
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/app/dashboard/chat/VisualizationInterface.tsx
+++ b/app/dashboard/chat/VisualizationInterface.tsx
@@ -6,6 +6,8 @@ import { Skeleton } from '@/components/ui/skeleton';
 interface VisualizationInterfaceProps {
   htmlContent: string;
   htmlLoading: boolean;
+  htmlError: string | null;
+  setHtmlError: (error: string | null) => void;
   iframeRef: RefObject<HTMLIFrameElement | null>;
   handlePrint: () => void;
   handleDownloadPdf: () => void;
@@ -20,6 +22,8 @@ interface VisualizationInterfaceProps {
 export default function VisualizationInterface({
   htmlContent,
   htmlLoading,
+  htmlError,
+  setHtmlError,
   iframeRef,
   handlePrint,
   handleDownloadPdf,
@@ -96,8 +100,8 @@ export default function VisualizationInterface({
         )}
       </div>
 
-      <div className="flex-1 overflow-y-auto p-8 lg:p-12 scroll-smooth">
-        <div className="max-w-4xl mx-auto bg-white dark:bg-dark-surface rounded-xl shadow-[0_4px_20px_-4px_rgba(0,0,0,0.1)] dark:shadow-none border border-gray-200 dark:border-dark-border min-h-[800px] p-10 md:p-16 relative transition-all">
+      <div className="flex-1 overflow-auto scroll-smooth">
+        <div className="max-w-4xl mx-auto bg-white dark:bg-dark-surface rounded-xl shadow-[0_4px_20px_-4px_rgba(0,0,0,0.1)] dark:shadow-none border border-gray-200 dark:border-dark-border min-h-screen p-6 md:p-10 relative transition-all">
           {htmlLoading ? (
             <div className="flex flex-col gap-8 h-full">
               <div className="flex justify-between items-center">
@@ -120,7 +124,7 @@ export default function VisualizationInterface({
               <iframe
                 ref={iframeRef}
                 srcDoc={htmlContent}
-                className="w-full h-full min-h-[800px] border-0 rounded-xl"
+                className="w-full h-full border-0 rounded-xl"
                 title="Visualization"
                 sandbox="allow-scripts allow-popups allow-forms allow-same-origin allow-modals"
               />
@@ -133,6 +137,24 @@ export default function VisualizationInterface({
                   onFeedbackSubmitted={onFeedbackSubmitted}
                 />
               )}
+            </div>
+          ) : htmlError ? (
+            <div className="flex flex-col items-center justify-center h-full min-h-screen text-red-600 dark:text-red-400 p-6">
+              <span className="material-symbols-outlined text-8xl mb-4 opacity-70">
+                error_outline
+              </span>
+              <p className="text-lg font-medium mb-2">
+                Error al generar la visualización
+              </p>
+              <p className="text-sm text-center max-w-md opacity-90">
+                {htmlError}
+              </p>
+              <button
+                onClick={handleVisualize}
+                className="mt-6 px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 transition-colors text-sm font-medium"
+              >
+                Reintentar
+              </button>
             </div>
           ) : (
             <div className="flex flex-col items-center justify-center h-full min-h-[400px] text-gray-300 dark:text-gray-400">

--- a/app/dashboard/chat/chat-client.tsx
+++ b/app/dashboard/chat/chat-client.tsx
@@ -26,6 +26,8 @@ export default function ChatClient({
     loading,
     htmlContent,
     htmlLoading,
+    htmlError,
+    setHtmlError,
     childInfo,
     topic,
     setTopic,
@@ -297,6 +299,8 @@ export default function ChatClient({
           <VisualizationInterface
             htmlContent={htmlContent}
             htmlLoading={htmlLoading}
+            htmlError={htmlError}
+            setHtmlError={setHtmlError}
             iframeRef={iframeRef}
             handlePrint={handlePrint}
             handleDownloadPdf={handleDownloadPdf}

--- a/app/dashboard/chat/hooks.ts
+++ b/app/dashboard/chat/hooks.ts
@@ -29,6 +29,7 @@ export const useChatInfo = (
   const [showTopicCustom, setShowTopicCustom] = useState(false); // Para mostrar input cuando es "Otros"
 
   const [noCreditsModalOpen, setNoCreditsModalOpen] = useState(false);
+  const [htmlError, setHtmlError] = useState<string | null>(null);
 
   // Sync state with prop
   useEffect(() => {
@@ -157,18 +158,25 @@ export const useChatInfo = (
     if (!lastAgentMsg) return;
 
     // Check for credits
-    // Check for credits
     const hasCredits = await checkCredits();
     if (!hasCredits) return;
 
     setHtmlLoading(true);
+    setHtmlError(null);
     try {
       const res = await sendMessageToMaquetin([
         { role: 'user', content: lastAgentMsg.content },
       ]);
       setHtmlContent(cleanHtmlResponse(res.message));
-    } catch (e) {
-      console.error(e);
+      setHtmlError(null);
+    } catch (error) {
+      console.error('Error en visualización:', error);
+      const errorMessage =
+        error instanceof Error ? error.message : 'Error desconocido';
+      setHtmlError(
+        `Hubo un error al generar la visualización: ${errorMessage}. Por favor, intenta de nuevo.`
+      );
+      setHtmlContent('');
     } finally {
       setHtmlLoading(false);
     }
@@ -182,6 +190,8 @@ export const useChatInfo = (
     htmlContent,
     setHtmlContent,
     htmlLoading,
+    htmlError,
+    setHtmlError,
     childInfo,
     topic,
     setTopic,

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -46,7 +46,7 @@ export default async function DashboardLayout({
   return (
     <div className="flex h-screen w-full bg-background-light dark:bg-background-dark font-display text-[#111813] dark:text-white transition-colors duration-200 overflow-hidden">
       {/* Sidebar (Desktop) */}
-      <aside className="hidden lg:flex w-64 flex-col border-r border-gray-100 dark:border-gray-800 bg-white dark:bg-dark-surface shadow-sm z-20">
+      <aside className="hidden lg:flex w-56 flex-col border-r border-gray-100 dark:border-gray-800 bg-white dark:bg-dark-surface shadow-sm z-20">
         {/* Links */}
         <nav className="flex-1 flex flex-col gap-1 p-4 overflow-y-auto">
           {/* PRINCIPAL */}
@@ -113,7 +113,7 @@ export default async function DashboardLayout({
         </header>
 
         {/* Scrollable Content Area */}
-        <main className="flex-1 overflow-y-auto overflow-x-hidden p-4 md:p-6 lg:p-8 relative">
+        <main className="flex-1 overflow-hidden p-0 relative">
           <div className="max-w-7xl mx-auto w-full h-full">{children}</div>
         </main>
       </div>


### PR DESCRIPTION
## Descripción

Se ha optimizado significativamente el layout del dashboard eliminando elementos innecesarios y mejorando el uso del espacio.

## Cambios principales

### Layout del Chat
- ✅ Remover header "Creador de fichas" que ocupaba espacio innecesario
- ✅ Implementar flex layout para mejor distribución automática de alturas
- ✅ Topic selector y input con `shrink-0` (altura fija)
- ✅ Área de mensajes con `overflow-auto` (scroll solo si necesita)

### Layout General
- ✅ Sidebar más compacto: `w-64` → `w-56`
- ✅ Main layout: `overflow-y-auto` → `overflow-hidden` (deja que hijos controlen scroll)
- ✅ Remover padding del main: `p-4 md:p-6 lg:p-8` → `p-0`

### Visualización
- ✅ Cambiar a `overflow-auto` (scroll flexible)
- ✅ Remover `min-h-[800px]` del card e iframe (ocupan solo lo necesario)
- ✅ Agregar `min-h-screen` + padding moderado al card

### Error Handling
- ✅ Nuevo estado `htmlError` para capturar errores de visualización
- ✅ Mostrar mensaje de error con icono y descripción
- ✅ Botón "Reintentar" para reintentarlo sin recargar página
- ✅ Limpiar error al intentar de nuevo

## Beneficios
- ✅ Pantalla completa ocupada sin desperdicio
- ✅ Scroll del navegador solo cuando es necesario
- ✅ Interfaz más limpia y profesional
- ✅ Mejor UX cuando falla la API (mensaje claro + reintento fácil)
- ✅ Mejor aprovechamiento del espacio en dispositivos pequeños